### PR TITLE
Update CMake arguments for MacOS build

### DIFF
--- a/build/BuildMacOSTask.cs
+++ b/build/BuildMacOSTask.cs
@@ -13,7 +13,7 @@ public sealed class BuildMacOSTask : FrostingTask<BuildContext>
         Directory.CreateDirectory(buildWorkingDir);
         // Path relative to the buildWorkingDir
         var cmakeListsPath = System.IO.Path.Combine("..", "crunch", "CMakeLists.txt");
-        context.StartProcess("cmake", new ProcessSettings { WorkingDirectory = buildWorkingDir, Arguments = $"-DCMAKE_OSX_ARCHITECTURES=\"x86_64;arm64\" -DCMAKE_BUILD_TYPE=Release -DBUILD_CRUNCH=ON -DBUILD_SHARED_LIBCRN=OFF -DBUILD_SHARED_LIBS=OFF -DBUILD_EXAMPLES=OFF {cmakeListsPath}" });
+        context.StartProcess("cmake", new ProcessSettings { WorkingDirectory = buildWorkingDir, Arguments = $"-DCMAKE_OSX_DEPLOYMENT_TARGET=10.15 -DCMAKE_OSX_ARCHITECTURES=\"x86_64;arm64\" -DCMAKE_BUILD_TYPE=Release -DBUILD_CRUNCH=ON -DBUILD_SHARED_LIBCRN=OFF -DBUILD_SHARED_LIBS=OFF -DBUILD_EXAMPLES=OFF {cmakeListsPath}" });
         context.StartProcess("make", new ProcessSettings { WorkingDirectory = buildWorkingDir, Arguments = "" });
         var files = Directory.GetFiles(buildWorkingDir, "crunch", SearchOption.TopDirectoryOnly);
         context.CopyFile(files[0], $"{context.ArtifactsDir}/crunch");


### PR DESCRIPTION
Add `-DCMAKE_OSX_DEPLOYMENT_TARGET=10.15` to the build system

Fixes https://github.com/MonoGame/MonoGame/issues/9013